### PR TITLE
Remove duplicate clock signal in arty a7 constraints

### DIFF
--- a/hw/constraints/xc7a35ticsg324-1l.xdc
+++ b/hw/constraints/xc7a35ticsg324-1l.xdc
@@ -9,11 +9,6 @@
 #set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { CLK100MHZ }]; #IO_L12P_T1_MRCC_35 Sch=gclk[100]
 #create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { CLK100MHZ }];
 
-# Clock signal
-
-#set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { sys_clock }]; #IO_L12P_T1_MRCC_35 Sch=gclk[100]
-#create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {sys_clock}];
-
 ## Switches
 set_property -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports { sw[0] }]; #IO_L12N_T1_MRCC_16 Sch=sw[0]
 set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 } [get_ports { sw[1] }]; #IO_L13P_T2_MRCC_16 Sch=sw[1]


### PR DESCRIPTION
The clock signal stanza in the arty a7 constraints file was defined
twice. This removes one to be compliant with the upstream source of the
constraints file.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>