### PR TITLE
Use localparam for uart states

### DIFF
--- a/hw/rtl/uart_tx.v
+++ b/hw/rtl/uart_tx.v
@@ -26,11 +26,11 @@ module uart_tx(
     reg [2:0] state;
 
     // states
-    parameter s_idle = 3'b000;
-    parameter s_start_bit = 3'b001;
-    parameter s_data_bit = 3'b010;
-    parameter s_stop_bit = 3'b011;
-    parameter s_cleanup = 3'b100;
+    localparam s_idle = 3'b000;
+    localparam s_start_bit = 3'b001;
+    localparam s_data_bit = 3'b010;
+    localparam s_stop_bit = 3'b011;
+    localparam s_cleanup = 3'b100;
 
     // clock cycles per bit transmitted
     // 100000000 / 9600 ~= 10416


### PR DESCRIPTION
Uses localparam instead of parameter for states in uart_tx because they
should not be able to be overridden by parent modules.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>