### PR TITLE
Update ci workflow to be compatible with older verilator versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       run: sudo apt-get install -y verilator
     - name: verilate
       run: |
-        verilator -Wall -cc -Irtl top.v
+        verilator -Wall -cc -Irtl top.v --exe sim/top.cpp
         make -C obj_dir -f Vtop.mk
-        verilator -Wall --cc -Irtl top.v --exe --build sim/top.cpp
         ./obj_dir/Vtop


### PR DESCRIPTION
The currently distributed deb for verilator uses an older version that
does not include the --build flag. We can accomplish the same steps by
excluding it.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>