### PR TITLE
Remove extraneous verilator commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,6 @@ All RTL is simulated using [Verilator](https://github.com/verilator/verilator).
 Simulation can be run with the following commands:
 
 ```
-verilator -Wall -cc -Irtl top.v
-make -C obj_dir -f Vtop.mk
 verilator -Wall --cc -Irtl top.v --exe --build sim/top.cpp
 ./obj_dir/Vtop
 ```


### PR DESCRIPTION
Removes extraneous commands that are replaced by --build flag in newer
versions of verilator.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>