### PR TITLE
Only run verilator when rtl or sim changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
-  pull_request: {}
+    paths:
+     - 'rtl/**'
+     - 'sim/**'
+  pull_request:
+    paths:
+     - 'rtl/**'
+     - 'sim/**'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
Modifies CI workflow to only run when the rtl or sim directories have
diffs.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #20 