### PR TITLE
Add trace flag to verilator command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ All RTL is simulated using [Verilator](https://github.com/verilator/verilator).
 Simulation can be run with the following commands:
 
 ```
-verilator -Wall --cc -Irtl top.v --exe --build sim/top.cpp
+verilator -Wall --cc -Irtl --trace top.v --exe --build sim/top.cpp
 ./obj_dir/Vtop
 ```
 


### PR DESCRIPTION
Adds the --trace flag to the verilator build such that we are able to
generate vcd files to use with gtkwave.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>