### PR TITLE
Add simulation section and clean up os section of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,20 +24,16 @@ HARTS=1
 GDB=$(TOOLCHAIN)gdb
 OBJDUMP=$(TOOLCHAIN)objdump
 
-## Setup
-## =============
-
-setup:
-	@mkdir -p $(OUTDIR)
-
 ## Build
 ## =============
 
 $(OUTDIR)/%.o: $(SOURCES)
-	@$(AS) $(SOURCES) -o $@
+	@mkdir -p $(@D)
+	@$(AS) $^ -o $@
 
 $(BIN): $(OBJ)
-	@$(LD) -T$(LINKER_SCRIPT) $(OBJ) -o $@
+	@mkdir -p $(@D)
+	@$(LD) -T$(LINKER_SCRIPT) $^ -o $@
 
 build: $(BIN)
 


### PR DESCRIPTION
Previously the OS targets were rebuilding every invocation (i.e. used
named targets that weren't files). This refactors to only build when
necessary. It also adds a hardware section with support for simulation.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>