### PR TITLE
Fix UART transmission

### DIFF
--- a/rtl/top.v
+++ b/rtl/top.v
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// timescale is formatted as <time_unit> / <time_precision>
 `timescale 1ns / 1ps
 
 module top(

--- a/rtl/uart_tx.v
+++ b/rtl/uart_tx.v
@@ -37,9 +37,9 @@ module uart_tx(
     parameter cycles = 10416;
 
     integer clock_count = 0;
-    integer word_index = 1;
-    integer bit_index = 1;
-    reg [8*31:1] tx_data = "\n\r!retupmoC ssoM eht ot emocleW";
+    integer word_index = 247;
+    integer bit_index = 7;
+    reg [8*31-1:0] tx_data = "Welcome to the Moss Computer!\r\n";
     reg stop = 1'b0;
     
     always @(posedge clk) begin
@@ -55,7 +55,7 @@ module uart_tx(
                 else
                     begin
                         clock_count <= 0;
-                        bit_index <= 1;
+                        bit_index <= 7;
                         state <= s_data_bit;
                         if (reset)
                             begin
@@ -85,7 +85,7 @@ module uart_tx(
             end
         s_data_bit:
             begin
-                out <= tx_data[word_index];
+                out <= tx_data[word_index-bit_index];
                 if (clock_count < cycles-1)
                     begin
                         clock_count <= clock_count+1;
@@ -94,20 +94,20 @@ module uart_tx(
                 else
                     begin
                         clock_count <= 0;
-                        if (bit_index < 8)
+                        if (bit_index > 0)
                             begin
-                                bit_index <= bit_index+1;
-                                word_index <= word_index+1;
+                                bit_index <= bit_index-1;
                                 state <= s_data_bit;
                             end
                         else
                             begin
-                                bit_index <= 1;
-                                word_index <= word_index+1;
+                                bit_index <= 7;
+                                word_index <= word_index-8;
                                 state <= s_stop_bit;
                             end
                     end
             end
+            // 
         s_stop_bit:
             begin
                 out <= 1'b1;
@@ -124,9 +124,9 @@ module uart_tx(
             end
         s_cleanup:
             begin
-                if (word_index >= 247)
+                if (word_index < 7)
                     begin
-                        word_index <= 1;
+                        word_index <= 247;
                         stop <= 1'b1;
                     end
                 state <= s_idle;

--- a/toolchain/vivado/boards/xc7a35ticsg324-1l/xc7a35ticsg324-1l.xpr
+++ b/toolchain/vivado/boards/xc7a35ticsg324-1l/xc7a35ticsg324-1l.xpr
@@ -3,7 +3,7 @@
 <!--                                                         -->
 <!-- Copyright 1986-2020 Xilinx, Inc. All Rights Reserved.   -->
 
-<Project Version="7" Minor="49" Path="/home/dan/code/github.com/mosscomputer/moss/toolchain/vivado/boards/xc7a35ticsg324-1l/xc7a35ticsg324-1l.xpr">
+<Project Version="7" Minor="49" Path="/home/dan/code/github.com/mosscomp/moss/toolchain/vivado/boards/xc7a35ticsg324-1l/xc7a35ticsg324-1l.xpr">
   <DefaultLaunch Dir="$PRUNDIR"/>
   <Configuration>
     <Option Name="Id" Val="944d562fd6124d98858265b7e6a4700f"/>


### PR DESCRIPTION
Fixes previous behavior of sending messages over UART in reverse.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

```
🤖 (moss) xxd -b < /dev/ttyUSB1
00000000: 01010111 01100101 01101100 01100011 01101111 01101101  Welcom
00000006: 01100101 00100000 01110100 01101111 00100000 01110100  e to t
0000000c: 01101000 01100101 00100000 01001101 01101111 01110011  he Mos
00000012: 01110011 00100000 01000011 01101111 01101101 01110000  s Comp
00000018: 01110101 01110100 01100101 01110010 00100001 00001101  uter!.
```